### PR TITLE
feat(ssa): add loop nesting forest pass

### DIFF
--- a/src/ssa.rs
+++ b/src/ssa.rs
@@ -2,6 +2,7 @@ pub mod error;
 pub mod fbuilder;
 pub mod function;
 pub mod instr;
+pub mod macros;
 pub mod module;
 pub mod passes;
 
@@ -63,7 +64,7 @@ impl fmt::Display for ValueType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Phi {
     pub var: Variable,
     pub value: Value,
@@ -83,11 +84,13 @@ impl Phi {
     }
 }
 
+#[derive(Clone)]
 pub struct ValueData {
     pub value_type: ValueType,
     pub value_kind: ValueKind,
 }
 
+#[derive(Clone)]
 pub enum ValueKind {
     InstrRes(instr::Instr),
     FuncArg,
@@ -150,7 +153,7 @@ pub struct VariableData {
     pub var_type: ValueType,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Block(usize);
 
 impl EntityId for Block {
@@ -184,6 +187,7 @@ pub enum BlockSealStatus {
     Sealed,
 }
 
+#[derive(Clone)]
 pub struct BlockData {
     pub predecessors: Vec<Block>,
     pub successors: Vec<Block>,

--- a/src/ssa/function.rs
+++ b/src/ssa/function.rs
@@ -53,6 +53,7 @@ pub struct Signature {
     pub ret_type: Option<ValueType>,
 }
 
+#[derive(Clone)]
 pub struct FunctionData {
     pub(super) signature: Signature,
     pub(super) blocks: DenseMap<Block, BlockData>,

--- a/src/ssa/macros.rs
+++ b/src/ssa/macros.rs
@@ -1,0 +1,64 @@
+#[doc(hidden)]
+macro_rules! __instr__ {
+    ($builder:ident: #vdef $var:ident $val:ident) => {
+        $builder.define_variable($var, $val)
+            .expect("var def");
+    };
+
+    ($builder:ident: #block $name:ident) => {
+        let $name = $builder.make_block().expect("make block");
+    };
+
+    ($builder:ident: #seal $block:ident) => {
+        $builder.seal_block($block).expect("block seal");
+    };
+
+    ($builder:ident: #switch $block:ident) => {
+        $builder.switch_to_block($block).expect("switch block");
+    };
+
+    ($builder:ident: #vdecl $res:ident $name:literal::$var_type:ident) => {
+        let $res = $builder.declare_variable(
+            $name.to_string(),
+            $crate::ssa::ValueType::$var_type
+        )
+        .expect("var decl");
+    };
+
+    ($builder:ident: #vuse $var:ident $($res:ident)?) => {
+        $(let $res =)? $builder.use_variable($var).expect("var use");
+    };
+
+    ($builder:ident: $res:ident = $ins:ident $($arg:expr),+) => {
+        let $res = $builder.ins().$ins($($arg),+).expect("instruction addition");
+    };
+
+    ($builder:ident: brs $cond:ident, $then:ident, $else:ident) => {
+        $builder
+            .ins()
+            .brs($crate::ssa::instr::Cond::$cond, $then, $else)
+            .expect("brs instr");
+    };
+
+    ($builder:ident: $ins:ident $($arg:expr),+) => {
+        $builder.ins().$ins($($arg),+).expect("instruction addition");
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use __instr__;
+
+#[macro_export]
+macro_rules! build_function {
+    ($(($($tree:tt)+))+) => {{
+        let isa = $crate::ssa::function::InstructionSet::Thumb;
+        let mut module = $crate::ssa::module::SsaModule::construct(isa);
+        let mut b = module.build_function(module.get_main_function()).expect("get builder");
+
+        $(
+            $crate::ssa::macros::__instr__!(b:$($tree)+);
+        )+
+
+        b.func_data.clone()
+    }};
+}

--- a/src/ssa/passes.rs
+++ b/src/ssa/passes.rs
@@ -1,7 +1,13 @@
 pub mod critical_edge_removal;
+pub mod dfs_tree;
+pub mod loop_nesting_forest;
+
+pub use critical_edge_removal::CriticalEdgeRemoval;
+pub use dfs_tree::DfsTree;
 
 use std::{
     any::{Any, TypeId},
+    cell::RefCell,
     rc::Rc,
 };
 
@@ -31,6 +37,13 @@ pub struct PassManager<'a> {
 }
 
 impl<'a> PassManager<'a> {
+    pub fn new(func: &'a mut FunctionData) -> Self {
+        Self {
+            function_data: func,
+            pass_results: FxHashMap::default(),
+        }
+    }
+
     pub fn ensure_pass<T: Pass + 'static>(&mut self) -> UxoResult<(), T::Error> {
         let type_id = TypeId::of::<T>();
         if self.pass_results.contains_key(&type_id) {
@@ -39,17 +52,18 @@ impl<'a> PassManager<'a> {
 
         T::dependencies(PassDepTracker::new(self))?;
         let res = T::execute(PassStore::new(self))?;
-        self.pass_results.insert(type_id, Rc::new(res));
+        self.pass_results
+            .insert(type_id, Rc::new(RefCell::new(res)));
         Ok(())
     }
 
-    pub fn get_pass<T: Pass + 'static>(&self) -> UxoResult<Rc<T>, PassManagerError> {
+    pub fn get_pass<T: Pass + 'static>(&self) -> UxoResult<Rc<RefCell<T>>, PassManagerError> {
         self.pass_results
             .get(&TypeId::of::<T>())
             .ok_or_else(|| PassManagerError::PassNotFound(T::name()))
             .into_report()?
             .clone()
-            .downcast::<T>()
+            .downcast::<RefCell<T>>()
             .map_err(|_| PassManagerError::RetrievalDowncastFailure(T::name()))
             .into_report()
     }
@@ -78,11 +92,184 @@ impl<'short, 'long> PassStore<'short, 'long> {
         Self { manager }
     }
 
-    pub fn get_pass<T: Pass + 'static>(&self) -> UxoResult<Rc<T>, PassManagerError> {
+    pub fn get_pass<T: Pass + 'static>(&self) -> UxoResult<Rc<RefCell<T>>, PassManagerError> {
         self.manager.get_pass::<T>()
     }
 
-    pub fn get_func(&mut self) -> &mut FunctionData {
+    pub fn get_func(&self) -> &FunctionData {
         self.manager.function_data
+    }
+
+    pub fn get_func_mut(&mut self) -> &mut FunctionData {
+        self.manager.function_data
+    }
+}
+
+#[cfg(test)]
+mod test_utils {
+    use super::*;
+
+    pub fn get_pass<T: Pass + 'static>(func: &mut FunctionData) -> Rc<RefCell<T>> {
+        let mut manager = PassManager::new(func);
+        manager.ensure_pass::<T>().expect("ensure pass");
+        manager.get_pass::<T>().expect("pass")
+    }
+
+    pub fn get_function_with_single_loop() -> FunctionData {
+        crate::build_function! {
+            // HEAD
+            (#block while_header)
+            (#block continuation)
+            (#block inside_while)
+            (#block inside_then)
+            (#block inside_else)
+            (#block while_end)
+            (#vdecl var "test"::Int32)
+
+            // start block
+            (v0 = const32 34)
+            (#vdef var v0)
+            (jmp while_header)
+
+            // while header
+            (#switch while_header)
+            (#vuse var v)
+            (c67 = const32 67)
+            (cmps v, c67)
+            (brs LessThan, inside_while, continuation)
+
+            (#seal continuation)
+            (#seal inside_while)
+
+            // inside while
+            (#switch inside_while)
+            (c10 = const32 10)
+            (c11 = const32 11)
+            (cmps c10, c11)
+            (brs LessThan, inside_then, inside_else)
+
+            (#seal inside_then)
+            (#seal inside_else)
+
+            // inside then
+            (#switch inside_then)
+            (#vuse var v)
+            (c100 = const32 100)
+            (add_res = add v, c100)
+            (#vdef var add_res)
+            (jmp while_end)
+
+            // inside else
+            (#switch inside_else)
+            (c200 = const32 200)
+            (c201 = const32 201)
+            (sub c201, c200)
+            (jmp while_end)
+
+            (#seal while_end)
+
+            // while end
+            (#switch while_end)
+            (jmp while_header)
+
+            (#seal while_header)
+
+            // continuation
+            (#switch continuation)
+            (#vuse var v)
+            (c2 = const32 2)
+            (res = mul v, c2)
+            (ret Some(res))
+        }
+    }
+
+    pub fn get_function_with_nested_loops() -> FunctionData {
+        crate::build_function! {
+            // HEAD & decls
+            (#block while_header)
+            (#block continuation)
+            (#block while_inside)
+            (#block n_while_header)
+            (#block n_continuation)
+            (#block n_inside_if_header)
+            (#block n_inside_if_then)
+            (#block n_inside_if_else)
+            (#block n_inside_if_merge)
+            (#vdecl var "test"::Int8)
+
+            // start block
+            (c = const8 0)
+            (#vdef var c)
+            (jmp while_header)
+
+            // while header
+            (#switch while_header)
+            (#vuse var v)
+            (c = const8 10)
+            (cmps v, c)
+            (brs LessThan, while_inside, continuation)
+
+            (#seal while_inside)
+            (#seal continuation)
+
+            // while_inside
+            (#switch while_inside)
+            (c = const8 20)
+            (#vdef var c)
+            (jmp n_while_header)
+
+            // nested while header
+            (#switch n_while_header)
+            (#vuse var v)
+            (c = const8 30)
+            (cmps c, v)
+            (brs GreaterThan, n_inside_if_header, n_continuation)
+
+            (#seal n_inside_if_header)
+            (#seal n_continuation)
+
+            // nested if header
+            (#switch n_inside_if_header)
+            (#vuse var v)
+            (c = const8 40)
+            (cmps c, v)
+            (brs LessThan, n_inside_if_then, n_inside_if_else)
+
+            (#seal n_inside_if_then)
+            (#seal n_inside_if_else)
+
+            // nested if then
+            (#switch n_inside_if_then)
+            (c = const8 50)
+            (#vdef var c)
+            (jmp n_inside_if_merge)
+
+            // nested if else
+            (#switch n_inside_if_else)
+            (c = const8 60)
+            (#vdef var c)
+            (jmp n_inside_if_merge)
+
+            (#seal n_inside_if_merge)
+
+            // nested if merge
+            (#switch n_inside_if_merge)
+            (jmp n_while_header)
+
+            (#seal n_while_header)
+
+            // nested continuation
+            (#switch n_continuation)
+            (jmp while_header)
+
+            (#seal while_header)
+
+            // continuation
+            (#switch continuation)
+            (#vuse var v)
+            (c = const8 70)
+            (res = mul v, c)
+            (ret Some(res))
+        }
     }
 }

--- a/src/ssa/passes/critical_edge_removal.rs
+++ b/src/ssa/passes/critical_edge_removal.rs
@@ -123,7 +123,7 @@ impl Pass for CriticalEdgeRemoval {
     }
 
     fn execute(mut store: PassStore) -> UxoResult<Self, Self::Error> {
-        remove_critical_edges(store.get_func())?;
+        remove_critical_edges(store.get_func_mut())?;
         Ok(Self)
     }
 }

--- a/src/ssa/passes/dfs_tree.rs
+++ b/src/ssa/passes/dfs_tree.rs
@@ -1,0 +1,230 @@
+use error_stack::{IntoReport, ResultExt};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{
+    ssa::{function::FunctionData, passes, Block},
+    utils::{DenseMap, EntityId, UxoResult},
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum DfsTreeError {
+    #[error("a dependency pass failed for 'dfs_tree'")]
+    DependentPassFailed,
+    #[error("there was an error when interacting with the function data")]
+    FunctionError,
+    #[error("block not found in result map")]
+    ResBlockNotFound,
+    #[error("there was an inexplicable failure")]
+    InexplicableFailure,
+}
+
+struct BlockIndexVec {
+    indices: FxHashMap<Block, usize>,
+    block_vec: Vec<Block>,
+}
+
+impl BlockIndexVec {
+    fn new() -> Self {
+        Self {
+            indices: FxHashMap::default(),
+            block_vec: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, block: Block) -> bool {
+        if self.indices.contains_key(&block) {
+            return false;
+        }
+
+        let idx = self.block_vec.len();
+        self.indices.insert(block, idx);
+        self.block_vec.push(block);
+        true
+    }
+
+    fn truncate_until(&mut self, block: Block) -> bool {
+        if let Some(idx) = self.indices.get(&block).copied() {
+            for further_block in self.block_vec.iter().skip(idx + 1) {
+                self.indices.remove(further_block);
+            }
+            self.block_vec.truncate(idx + 1);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn contains(&self, block: Block) -> bool {
+        self.indices.contains_key(&block)
+    }
+}
+
+pub struct DfsTree {
+    pub tree: DenseMap<Block, Vec<Block>>,
+    pub back_edges: FxHashSet<(Block, Block)>,
+    pub postorder: Vec<Block>,
+}
+
+impl DfsTree {
+    fn from_function(func: &FunctionData) -> UxoResult<Self, DfsTreeError> {
+        let mut res_map: DenseMap<Block, Vec<Block>> = DenseMap::with_prefilled(func.blocks.len());
+
+        let first_block = Block::with_id(0);
+        let mut stack: Vec<(Block, Block)> = Vec::new();
+        let mut visited: FxHashSet<Block> = FxHashSet::default();
+        let mut idx_map = BlockIndexVec::new();
+        let mut back_edges: FxHashSet<(Block, Block)> = FxHashSet::default();
+        let mut rev_postorder: Vec<Block> = Vec::new();
+        visited.insert(first_block);
+        idx_map.push(first_block);
+        rev_postorder.push(first_block);
+
+        for succ in func
+            .get_block_succs(first_block)
+            .change_context(DfsTreeError::FunctionError)
+            .attach_printable("when getting first block successors")?
+        {
+            stack.push((first_block, succ));
+        }
+
+        while let Some((pred, next_block)) = stack.pop() {
+            idx_map.truncate_until(pred);
+            if visited.contains(&next_block) {
+                if idx_map.contains(next_block) {
+                    back_edges.insert((pred, next_block));
+                }
+                continue;
+            }
+            visited.insert(next_block);
+            idx_map.push(next_block);
+            rev_postorder.push(next_block);
+
+            res_map
+                .get_mut(pred)
+                .ok_or(DfsTreeError::ResBlockNotFound)
+                .into_report()?
+                .push(next_block);
+
+            for succ in func
+                .get_block_succs(next_block)
+                .change_context(DfsTreeError::FunctionError)
+                .attach_printable("when getting next_block successors")?
+            {
+                if !visited.contains(&succ) {
+                    stack.push((next_block, succ));
+                } else if idx_map.contains(succ) {
+                    back_edges.insert((next_block, succ));
+                }
+            }
+        }
+
+        Ok(Self {
+            tree: res_map,
+            back_edges,
+            postorder: rev_postorder.into_iter().rev().collect(),
+        })
+    }
+}
+
+impl passes::Pass for DfsTree {
+    type Error = DfsTreeError;
+
+    fn name() -> String {
+        "dfs_tree".to_string()
+    }
+
+    fn dependencies(mut tracker: passes::PassDepTracker) -> UxoResult<(), Self::Error> {
+        tracker
+            .dependency::<passes::CriticalEdgeRemoval>()
+            .change_context(DfsTreeError::DependentPassFailed)?;
+
+        Ok(())
+    }
+
+    fn execute(mut store: passes::PassStore) -> UxoResult<Self, Self::Error> {
+        DfsTree::from_function(store.get_func())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ssa::passes::test_utils;
+
+    #[test]
+    fn test_valid_dfs_tree() {
+        let mut func_data = test_utils::get_function_with_single_loop();
+        let dfs_tree = test_utils::get_pass::<DfsTree>(&mut func_data);
+        let dfs_tree = dfs_tree.borrow();
+
+        let postorder_set: FxHashSet<Block> = dfs_tree.postorder.iter().copied().collect();
+
+        let func_blocks: FxHashSet<Block> = func_data.blocks.keys().collect();
+
+        assert_eq!(
+            postorder_set.len(),
+            func_blocks.len(),
+            "postorder set and total blocks have differing lengths",
+        );
+
+        let diff: FxHashSet<Block> = postorder_set
+            .symmetric_difference(&func_blocks)
+            .copied()
+            .collect();
+
+        assert_eq!(
+            diff.len(),
+            0,
+            "difference between nodes of func blocks and postorder set",
+        );
+
+        let mut visited: FxHashSet<Block> = FxHashSet::default();
+        let mut stack: Vec<(Block, Block)> = Vec::new();
+        let first_block = Block::with_id(0);
+        visited.insert(first_block);
+
+        for succ in dfs_tree.tree.get(first_block).expect("first succs") {
+            stack.push((first_block, *succ));
+        }
+
+        while let Some((pred, next_block)) = stack.pop() {
+            assert!(
+                !visited.contains(&next_block),
+                "block visited twice, dfs tree is not a tree"
+            );
+            visited.insert(next_block);
+
+            let cfg_preds = func_data.get_block_preds(next_block).expect("cfg preds");
+
+            assert!(
+                cfg_preds.contains(&pred),
+                "edge in dfs tree doesn't exist in cfg",
+            );
+
+            for succ in dfs_tree.tree.get(next_block).expect("next succs") {
+                stack.push((next_block, *succ));
+            }
+        }
+
+        println!(
+            "THE PROGRAM:\n{}",
+            func_data.print().expect("print program")
+        );
+
+        println!("\nDFS Tree:\n");
+        for (node, succs) in dfs_tree.tree.iter() {
+            let block_strs: Vec<String> = succs.into_iter().map(|b| b.to_string()).collect();
+
+            println!("{} -> [{}]", node.to_string(), block_strs.join(", "));
+        }
+
+        println!("\nBACKEDGES:\n");
+        for (from, to) in dfs_tree.back_edges.iter() {
+            println!("{from} -> {to}");
+        }
+
+        let postorder_str: Vec<String> = dfs_tree.postorder.iter().map(|b| b.to_string()).collect();
+
+        println!("\nPOSTORDER: [{}]", postorder_str.join(", "));
+    }
+}

--- a/src/ssa/passes/loop_nesting_forest.rs
+++ b/src/ssa/passes/loop_nesting_forest.rs
@@ -1,0 +1,331 @@
+use std::collections::BTreeSet;
+
+use error_stack::{IntoReport, ResultExt};
+use rustc_hash::FxHashSet;
+
+use crate::{
+    ssa::{
+        function::FunctionData,
+        passes::{self, Pass, PassDepTracker, PassStore},
+        Block,
+    },
+    utils::{BoolExt, DenseMap, EntityId, UxoResult},
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoopForestError {
+    #[error("failed a dependency pass for 'loop_nesting_forest'")]
+    DependentPassFailure,
+    #[error("a block was not found in the union find data structure")]
+    UnionFindBlockNotFound,
+    #[error("a rank was not found in the union find data structure")]
+    UnionFindRankNotFound,
+    #[error("a block was not found in the forest")]
+    ForestBlockNotFound,
+    #[error("there was an error when interacting with the function data")]
+    FunctionError,
+}
+
+pub struct UnionFind {
+    pub parent: DenseMap<Block, Block>,
+    pub rank: DenseMap<Block, u16>,
+}
+
+impl UnionFind {
+    fn new(length: usize) -> Self {
+        let mut parent: DenseMap<Block, Block> = DenseMap::new();
+        let mut rank: DenseMap<Block, u16> = DenseMap::new();
+
+        for i in 0..length {
+            parent.insert(Block::with_id(i));
+            rank.insert(0);
+        }
+
+        Self { parent, rank }
+    }
+
+    fn find(&mut self, node: Block) -> UxoResult<Block, LoopForestError> {
+        let parent = self
+            .parent
+            .get(node)
+            .copied()
+            .ok_or(LoopForestError::UnionFindBlockNotFound)
+            .into_report()
+            .attach_printable("when trying to get parent")?;
+
+        if node == parent {
+            return Ok(node);
+        }
+
+        let grandparent = self.find(parent)?;
+
+        self.parent
+            .set(parent, grandparent)
+            .or_err(LoopForestError::UnionFindBlockNotFound)
+            .into_report()
+            .attach_printable("when trying to set parent to grandparent")?;
+
+        Ok(grandparent)
+    }
+
+    fn union(&mut self, mut n1: Block, mut n2: Block) -> UxoResult<(), LoopForestError> {
+        n1 = self.find(n1)?;
+        n2 = self.find(n2)?;
+
+        if n1 != n2 {
+            let mut r1 = self
+                .rank
+                .get(n1)
+                .copied()
+                .ok_or(LoopForestError::UnionFindRankNotFound)
+                .into_report()?;
+
+            let mut r2 = self
+                .rank
+                .get(n2)
+                .copied()
+                .ok_or(LoopForestError::UnionFindRankNotFound)
+                .into_report()?;
+
+            if r1 < r2 {
+                (n1, n2) = (n2, n1);
+                (r1, r2) = (r2, r1);
+            }
+
+            self.parent
+                .set(n2, n1)
+                .or_err(LoopForestError::UnionFindRankNotFound)
+                .into_report()?;
+
+            if r1 == r2 {
+                self.rank
+                    .set(n1, r1 + 1)
+                    .or_err(LoopForestError::UnionFindRankNotFound)
+                    .into_report()?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct LoopNestingForestBuilder<'a> {
+    func: &'a FunctionData,
+    dfs: &'a passes::DfsTree,
+    union_find: UnionFind,
+    forest: DenseMap<Block, Vec<Block>>,
+    roots: FxHashSet<Block>,
+}
+
+impl<'a> LoopNestingForestBuilder<'a> {
+    fn new(func: &'a FunctionData, dfs_tree: &'a passes::DfsTree) -> Self {
+        Self {
+            func,
+            dfs: dfs_tree,
+            union_find: UnionFind::new(func.blocks.len()),
+            forest: DenseMap::with_prefilled(func.blocks.len()),
+            roots: FxHashSet::default(),
+        }
+    }
+
+    fn collapse(
+        &mut self,
+        header: Block,
+        body: FxHashSet<Block>,
+    ) -> UxoResult<(), LoopForestError> {
+        let children_list = self
+            .forest
+            .get_mut(header)
+            .ok_or(LoopForestError::ForestBlockNotFound)
+            .into_report()?;
+
+        for loop_block in body {
+            children_list.push(loop_block);
+            self.union_find.union(header, loop_block)?;
+            self.roots.remove(&loop_block);
+        }
+
+        self.roots.insert(header);
+        Ok(())
+    }
+
+    fn find_loop(&mut self, potential_header: Block) -> UxoResult<(), LoopForestError> {
+        let mut loop_body: FxHashSet<Block> = FxHashSet::default();
+        let mut worklist: BTreeSet<Block> = self
+            .dfs
+            .back_edges
+            .iter()
+            .filter(|(_, b)| *b == potential_header)
+            .map(|(b, _)| self.union_find.find(*b))
+            .collect::<Result<_, _>>()?;
+        worklist.remove(&potential_header);
+
+        while let Some(block) = worklist.pop_first() {
+            loop_body.insert(block);
+
+            let preds = self
+                .func
+                .get_block_preds(block)
+                .change_context(LoopForestError::FunctionError)?;
+
+            for pred in preds {
+                if self.dfs.back_edges.contains(&(pred, block)) {
+                    continue;
+                }
+
+                let found = self.union_find.find(pred)?;
+
+                if found != potential_header
+                    && !loop_body.contains(&found)
+                    && !worklist.contains(&found)
+                {
+                    worklist.insert(found);
+                }
+            }
+        }
+
+        if !loop_body.is_empty() {
+            self.collapse(potential_header, loop_body)?;
+        }
+
+        Ok(())
+    }
+
+    fn build(mut self) -> UxoResult<LoopNestingForest, LoopForestError> {
+        for potential_header in self.dfs.postorder.iter().copied() {
+            self.find_loop(potential_header)?;
+        }
+
+        Ok(LoopNestingForest {
+            forest: self.forest,
+            top_level: self.roots,
+        })
+    }
+}
+
+pub struct LoopNestingForest {
+    pub forest: DenseMap<Block, Vec<Block>>,
+    pub top_level: FxHashSet<Block>,
+}
+
+impl Pass for LoopNestingForest {
+    type Error = LoopForestError;
+
+    fn name() -> String {
+        "loop_nesting_forest".to_string()
+    }
+
+    fn dependencies(mut tracker: PassDepTracker) -> crate::utils::UxoResult<(), Self::Error> {
+        tracker
+            .dependency::<passes::DfsTree>()
+            .change_context(LoopForestError::DependentPassFailure)?;
+        Ok(())
+    }
+
+    fn execute(store: PassStore) -> crate::utils::UxoResult<Self, Self::Error> {
+        let dfs_tree = store
+            .get_pass::<passes::DfsTree>()
+            .change_context(LoopForestError::DependentPassFailure)?;
+        let func = store.get_func();
+
+        let dfs_tree = dfs_tree.borrow();
+        let builder = LoopNestingForestBuilder::new(func, &dfs_tree);
+        builder.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ssa::passes::test_utils;
+
+    fn verify_loop_body(found: &FxHashSet<Block>, actual: &FxHashSet<Block>) {
+        assert_eq!(
+            found.len(),
+            actual.len(),
+            "invalid number of loop body nodes found",
+        );
+
+        let diff: FxHashSet<Block> = actual.symmetric_difference(&found).copied().collect();
+
+        assert!(
+            diff.is_empty(),
+            "difference between actual and found loop bodies"
+        );
+    }
+
+    #[test]
+    fn test_single_loop() {
+        let mut func_data = test_utils::get_function_with_single_loop();
+        let forest = test_utils::get_pass::<LoopNestingForest>(&mut func_data);
+        let forest = forest.borrow();
+
+        let block_1 = Block::with_id(1);
+        let succs: FxHashSet<Block> = forest
+            .forest
+            .get(block_1)
+            .expect("block_1 preds")
+            .iter()
+            .copied()
+            .collect();
+
+        let actual_succs = FxHashSet::from_iter([
+            Block::with_id(3),
+            Block::with_id(4),
+            Block::with_id(5),
+            Block::with_id(6),
+        ]);
+
+        verify_loop_body(&succs, &actual_succs);
+
+        println!("FOREST NODES:\n");
+        for (node, succs) in forest.forest.iter() {
+            let block_strs: Vec<String> = succs.iter().map(|b| b.to_string()).collect();
+
+            println!("{} -> [{}]", node.to_string(), block_strs.join(", "));
+        }
+    }
+
+    #[test]
+    fn test_nested_loop() {
+        let mut func = test_utils::get_function_with_nested_loops();
+        println!("NESTED LOOPS FUNC:\n{}", func.print().expect("print func"));
+        let forest = test_utils::get_pass::<LoopNestingForest>(&mut func);
+        let forest = forest.borrow();
+
+        verify_loop_body(
+            &forest
+                .forest
+                .get(Block::with_id(1))
+                .expect("block_1 preds")
+                .iter()
+                .copied()
+                .collect(),
+            &FxHashSet::from_iter([Block::with_id(3), Block::with_id(4), Block::with_id(5)]),
+        );
+
+        verify_loop_body(
+            &forest
+                .forest
+                .get(Block::with_id(4))
+                .expect("block_1 preds")
+                .iter()
+                .copied()
+                .collect(),
+            &FxHashSet::from_iter([
+                Block::with_id(6),
+                Block::with_id(7),
+                Block::with_id(8),
+                Block::with_id(9),
+            ]),
+        );
+
+        println!("ROOTS: {:?}", forest.top_level);
+        println!("FOREST NODES:\n");
+        for (node, succs) in forest.forest.iter() {
+            let block_strs: Vec<String> = succs.iter().map(|b| b.to_string()).collect();
+
+            println!("{} -> [{}]", node.to_string(), block_strs.join(", "));
+        }
+    }
+}

--- a/src/utils/dense_map.rs
+++ b/src/utils/dense_map.rs
@@ -10,6 +10,7 @@ pub trait EntityId {
     fn with_id(idx: usize) -> Self;
 }
 
+#[derive(Clone)]
 pub struct DenseMap<K, V> {
     data: Vec<V>,
     _marker: PhantomData<K>,
@@ -26,6 +27,20 @@ impl<K, V> DenseMap<K, V> {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             data: Vec::with_capacity(capacity),
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn with_prefilled(length: usize) -> Self
+    where
+        V: Default,
+    {
+        let mut data: Vec<V> = Vec::with_capacity(length);
+        for _ in 0..length {
+            data.push(V::default());
+        }
+        Self {
+            data,
             _marker: PhantomData,
         }
     }
@@ -51,6 +66,20 @@ where
     #[inline]
     pub fn get(&self, idx: K) -> Option<&V> {
         self.data.get(idx.get_id())
+    }
+
+    #[inline]
+    pub fn contains(&self, key: &K) -> bool {
+        key.get_id() < self.data.len()
+    }
+
+    pub fn set(&mut self, key: K, val: V) -> bool {
+        if self.contains(&key) {
+            self.data[key.get_id()] = val;
+            true
+        } else {
+            false
+        }
     }
 
     #[inline]
@@ -81,6 +110,11 @@ where
     #[inline]
     pub fn values_mut(&mut self) -> IterMut<'_, V> {
         self.data.iter_mut()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.data.len()
     }
 }
 


### PR DESCRIPTION
This PR adds a loop nesting forest pass and other dependent passes (like DFS Tree). The loop nesting forest will be used for Liveness Analysis.

Additionally, a new `build_function!()` macro was added to make SSA function building for tests more elegant.